### PR TITLE
Fix compile bug on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ ADD_DEFINITIONS(-Wall -Wextra -Wno-unused-parameter -Wno-unused-result)
 
 OPTION(USING_STD_REGEX "Use std::regex from C++ library instead of PCRECPP" OFF)
 
-IF(MACOS)
+IF(APPLE)
 	ADD_DEFINITIONS(-D_MACOS)
 ENDIF()
 


### PR DESCRIPTION
I got a compiling error (no member named '__cxx11') in make process after `cmake .` on macOS.
I found that `IF(MACOS)` in CMakeLists.txt is not working and should use `IF(APPLE)` instead.